### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(requirements_fname) as fp:
 
 setup(
     name="pyvisa_mock",
-    version="0.52",
+    version="0.52.1",
     packages=find_packages(),
     python_requires='>=3.6.*',
     install_requires=install_requires,


### PR DESCRIPTION
New version of pyvisa-mock is the same version number as microsoft fork of pyvisa-mock and this prevent automation from using the new build. Updated rev to reflect and fix